### PR TITLE
Prefixes of

### DIFF
--- a/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
+++ b/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
@@ -51,8 +51,9 @@ final class RadixTree[K, V](val prefix: K, private[radixtree] val children: Arra
 
   def filterPrefixesOf(query: K)(implicit K: Key[K]): RadixTree[K, V] = {
     val ft = filterPrefixesOf0(this, query, 0)
-
-    if (ft.prefix == K.empty && ! ft.children.isEmpty)  ft.children.head
+    if (ft.prefix == K.empty)
+      if (! ft.children.isEmpty) ft.children.head
+      else RadixTree.empty
     else ft
   }
 
@@ -147,7 +148,7 @@ final class RadixTree[K, V](val prefix: K, private[radixtree] val children: Arra
           copy(children = RadixTree.emptyChildren)
         }
       }
-    } else copy(children = RadixTree.emptyChildren)
+    } else RadixTree.empty
   }
 
   def modifyOrRemove(f: (K, V, Int) => Option[V])(implicit K: Key[K]): RadixTree[K, V] =

--- a/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
+++ b/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
@@ -49,6 +49,13 @@ final class RadixTree[K, V](val prefix: K, private[radixtree] val children: Arra
   def filterPrefix(prefix: K)(implicit K: Key[K]): RadixTree[K, V] =
     filterPrefix0(prefix, 0)
 
+  def filterPrefixesOf(query: K)(implicit K: Key[K]): RadixTree[K, V] = {
+    val ft = filterPrefixesOf0(this, query, 0)
+
+    if (ft.prefix == K.empty && ! ft.children.isEmpty)  ft.children.head
+    else ft
+  }
+
   def subtreeWithPrefix(prefix: K)(implicit K: Key[K]) = {
     val tree1 = filterPrefix(prefix)
     if (K.startsWith(tree1.prefix, prefix, 0))
@@ -120,6 +127,27 @@ final class RadixTree[K, V](val prefix: K, private[radixtree] val children: Arra
       }
     } else
       RadixTree.empty
+  }
+
+  private def filterPrefixesOf0(acc: RadixTree[K, V], query: K, offset: Int)(implicit K: Key[K]): RadixTree[K, V] = {
+    val ps = K.size(prefix)
+    val qs = K.size(query) - offset
+    val maxFd = ps min qs
+    val fd = K.indexOfFirstDifference(prefix, 0, query, offset, maxFd)
+    if (fd == maxFd) {
+      if (maxFd < ps) RadixTree.empty
+      else if (qs == ps) copy(children = RadixTree.emptyChildren)
+      else {
+        val index = K.binarySearch(children, query, offset + ps)
+        if (index >= 0) {
+          val child1 = children(index).filterPrefixesOf0(this, query, offset + ps)
+          val children1 = if (child1.isEmpty) RadixTree.emptyChildren[K, V] else Array(child1)
+          copy(children = children1)
+        } else {
+          copy(children = RadixTree.emptyChildren)
+        }
+      }
+    } else copy(children = RadixTree.emptyChildren)
   }
 
   def modifyOrRemove(f: (K, V, Int) => Option[V])(implicit K: Key[K]): RadixTree[K, V] =

--- a/src/test/scala/com/rklaehn/radixtree/RadixTreeTest.scala
+++ b/src/test/scala/com/rklaehn/radixtree/RadixTreeTest.scala
@@ -163,6 +163,12 @@ class RadixTreeTest extends FunSuite {
     assert(RadixTree("1" -> 1, "12" -> 12).filterPrefix("123").isEmpty)
   }
 
+  test("filterPrefixesOf") {
+    assert(RadixTree("1" -> 1).entries.toSeq === tree.filterPrefixesOf("1x").entries.toSeq)
+    assert(RadixTree("1" -> 1).filterPrefixesOf("foo").isEmpty)
+    assert(RadixTree("1" -> 1, "12" -> 12).filterPrefixesOf("2").isEmpty)
+  }
+
   test("modifyOrRemove") {
     val tree1 = tree.modifyOrRemove { case (k, v, _) => Some(v * 2) }
     val tree2 = tree.modifyOrRemove { case (k, v, _) => None }


### PR DESCRIPTION
I have added a filterPrefixesOf method (and associated test) for searching the tree for all prefixes of a search key.  Different use case than filterPrefix, but efficient for the problem in that it makes a traversal down to the longest node that matches then returns that path once a non-match is encountered.  See git commit message for more comments.

I needed this for some software I am building that needs to quickly find, from a collection of URI paths, all paths that are prefixes of a search path.  This served the purpose well.

Hopefully this addition is something you find would be generally useful.