### PR TITLE
Add getOrNull

### DIFF
--- a/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
+++ b/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
@@ -231,6 +231,11 @@ final class RadixTree[K, V](val prefix: K, private[radixtree] val children: Arra
 
   def getOrNull(key: K)(implicit K: Key[K]): V = get0(key, 0).ref
 
+  def getOrDefault[VV >: V](key: K, default: VV)(implicit K: Key[K]): VV = {
+    val o = get0(key, 0)
+    if (o.isDefined) o.get else default
+  }
+
   @tailrec
   private def get0(key: K, offset: Int)(implicit K: Key[K]): Opt[V] =
     if (K.startsWith(key, prefix, offset)) {

--- a/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
+++ b/src/main/scala/com/rklaehn/radixtree/RadixTree.scala
@@ -229,6 +229,8 @@ final class RadixTree[K, V](val prefix: K, private[radixtree] val children: Arra
 
   def get(key: K)(implicit K: Key[K]): Option[V] = get0(key, 0).toOption
 
+  def getOrNull(key: K)(implicit K: Key[K]): V = get0(key, 0).ref
+
   @tailrec
   private def get0(key: K, offset: Int)(implicit K: Key[K]): Opt[V] =
     if (K.startsWith(key, prefix, offset)) {

--- a/src/test/scala/com/rklaehn/radixtree/RadixTreeTest.scala
+++ b/src/test/scala/com/rklaehn/radixtree/RadixTreeTest.scala
@@ -228,6 +228,12 @@ class RadixTreeTest extends FunSuite {
     assert(Opt.empty[Int].toString === "Opt.empty")
   }
 
+  test("getOrNull") {
+    val t = RadixTree.singleton("ab", "x")
+    assert(t.getOrNull("ab") == "x")
+    assert(t.getOrNull("ba") eq null)
+  }
+
   test("eq") {
     Eq.eqv(tree, tree.packed)
   }

--- a/src/test/scala/com/rklaehn/radixtree/RadixTreeTest.scala
+++ b/src/test/scala/com/rklaehn/radixtree/RadixTreeTest.scala
@@ -234,6 +234,12 @@ class RadixTreeTest extends FunSuite {
     assert(t.getOrNull("ba") eq null)
   }
 
+  test("getOrDefault") {
+    val t = RadixTree.singleton("ab", 3)
+    assert(t.getOrDefault("ab", 7) == 3)
+    assert(t.getOrDefault("ba", 7) == 7)
+  }
+
   test("eq") {
     Eq.eqv(tree, tree.packed)
   }


### PR DESCRIPTION
This is more efficient than `get` or `contains` then `apply`.