### PR TITLE
Update to cats 1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,9 @@ lazy val commonSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := Function.const(false),
-  publishTo <<= version { v =>
+  publishTo := {
     val nexus = "https://oss.sonatype.org/"
-    if (v.trim.endsWith("SNAPSHOT"))
+    if (version.value.trim.endsWith("SNAPSHOT"))
       Some("Snapshots" at nexus + "content/repositories/snapshots")
     else
       Some("Releases" at nexus + "service/local/staging/deploy/maven2")
@@ -92,7 +92,7 @@ lazy val instrumentedTestSettings = {
     s"-javaagent:$jammJar"
   }
   Seq(
-    javaOptions in Test <+= (dependencyClasspath in Test).map(makeAgentOptions),
+    javaOptions in Test += makeAgentOptions((dependencyClasspath in Test).value),
       libraryDependencies += "com.github.jbellis" % "jamm" % "0.3.0" % "test",
       fork := true
     )

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
     "com.rklaehn" %%% "sonicreducer" % "0.5.0",
-    "org.typelevel" %%% "cats" % "0.9.0",
-    "org.typelevel" %%% "algebra" % "0.7.0",
-    "org.typelevel" %%% "algebra-laws" % "0.7.0" % "test",
+    "org.typelevel" %%% "cats-core" % "1.0.1",
+    "org.typelevel" %%% "algebra" % "1.0.0",
+    "org.typelevel" %%% "algebra-laws" % "1.0.0" % "test",
     "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
 
     // thyme

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17

--- a/src/main/scala/com/rklaehn/radixtree/Hash.scala
+++ b/src/main/scala/com/rklaehn/radixtree/Hash.scala
@@ -19,7 +19,7 @@ trait Hash[@sp A] extends Any with Eq[A] with Serializable { self =>
     * Constructs a new `Eq` instance for type `B` where 2 elements are
     * equivalent iff `eqv(f(x), f(y))`.
     */
-  override def on[@sp B](f: B => A): Hash[B] =
+  def on[@sp B](f: B => A): Hash[B] =
     new Hash[B] {
       def eqv(x: B, y: B): Boolean = self.eqv(f(x), f(y))
       def hash(x: B): Int = self.hash(f(x))

--- a/src/test/scala/com/rklaehn/radixtree/RadixTreeLawsCheck.scala
+++ b/src/test/scala/com/rklaehn/radixtree/RadixTreeLawsCheck.scala
@@ -5,8 +5,8 @@ import org.scalacheck.Arbitrary
 import org.scalatest.FunSuite
 import org.typelevel.discipline.scalatest.Discipline
 import Instances._
-import cats.kernel.laws.GroupLaws
 import algebra.laws.RingLaws
+import cats.kernel.laws.discipline.MonoidTests
 
 class RadixTreeLawsCheck extends FunSuite with Discipline {
 
@@ -17,8 +17,8 @@ class RadixTreeLawsCheck extends FunSuite with Discipline {
     RadixTree(kvs: _*)
   }
 
-  checkAll("GroupLaws[RadixTree[String, String]].monoid", GroupLaws[RadixTree[String, String]].monoid)
-  checkAll("GroupLaws[RadixTree[Array[Byte], Array[Byte]]].monoid", GroupLaws[RadixTree[Array[Byte], Array[Byte]]].monoid)
+  checkAll("MonoidTests[RadixTree[String, String]].monoid", MonoidTests[RadixTree[String, String]].monoid)
+  checkAll("MonoidTests[RadixTree[Array[Byte], Array[Byte]]].monoid", MonoidTests[RadixTree[Array[Byte], Array[Byte]]].monoid)
   checkAll("RingLaws[RadixTree[String, Byte]].additiveMonoid", RingLaws[RadixTree[String, Short]].additiveMonoid)
   checkAll("RingLaws[RadixTree[Array[Byte], Int]].additiveMonoid", RingLaws[RadixTree[String, Int]].additiveMonoid)
 }


### PR DESCRIPTION
This pull request updates the cats dependency to cats 1.0.1, to make radixtree work with Cats 1.x and upwards.

I also updated SBT to 0.13.17 along the way, out of convenience because 0.13.13 doesn't work with recent JDK releases.  If you mind I can remove the corresponding commit from this PR.

I'm unsure about the change concerning the `on` method: I removed the `override` identifier to make it build, and it looks like the code never used the super method anyway, but I don't know whether that's the appropriate change.